### PR TITLE
Fix artillery coordination distance compute

### DIFF
--- a/addons/interaction/functions/fnc_onMapClick.sqf
+++ b/addons/interaction/functions/fnc_onMapClick.sqf
@@ -62,7 +62,7 @@ switch (_entity getVariable "SSS_supportType") do {
 					};
 
 					_request in _magazines && _vehicle != _otherVehicle &&
-					{_vehicle distance2D _otherVehicle < (_x getVariable "SSS_coordinationDistance")} &&
+					{_vehicle distance2D _otherVehicle < (_entity getVariable "SSS_coordinationDistance")} &&
 					{(_x getVariable "SSS_cooldown") isEqualTo 0}
 				} else {
 					false


### PR DESCRIPTION
Before this patch: coordination distance between artilleries are computed from others artilleries coordination distance. The setting set on a support artillery is used by others artilleries.
Example:
Artillery A, coordination distance 100m
Artillery B, coordination distance 200m
Artilleries A and B are separated by 150m.
Artillery A can request a coordination with artillery B (because B has 200m configured)
Artillery B can't request a coordination with artillery A (because it's artillery A coordination distance which is used: 100m < 150m)

With this patch: coordination distance between artilleries is computed using the requested artillery coordination distance.
With the above example, now:
Artillery A can't request a coordination with artillery B
Artillery B can request a coordination with artillery A